### PR TITLE
Add addon status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TOS-Bandicam_removewatermark
+# TOS-Bandicam_removewatermark [![Addon Safe](https://cdn.rawgit.com/lubien/awesome-tos/master/badges/addon-safe.svg)](https://github.com/lubien/awesome-tos#addons-badges)
 Removes the watermark from the in-game Bandicam feature.  Press F12 to start recording, and F12 again to stop. The stop message won't be recorded.
 
 Installation:


### PR DESCRIPTION
I'm proposing a badge pattern for Tree of Savior addons.
Using these badges, users can easily understand that the system they are using is approved / is safe / have a unknown status / is unsafe.
Read more at [Awesome ToS #addons-badges](https://github.com/lubien/awesome-tos#addons-badges).
Also, I just added you repo to the [awesome-tos](https://github.com/lubien/awesome-tos) list.
Hope you like the idea.